### PR TITLE
Create separate dbs for jaws split across 2 motor controllers

### DIFF
--- a/jawsApp/Db/Makefile
+++ b/jawsApp/Db/Makefile
@@ -13,6 +13,8 @@ include $(TOP)/configure/CONFIG
 #DB += xxx.db
 DB += jaws.db
 DB += jaws_vertical.db
+DB += split_jaws_header_vertical.db
+DB += split_jaws_horizontal.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/jawsApp/Db/jaws.substitutions
+++ b/jawsApp/Db/jaws.substitutions
@@ -1,3 +1,5 @@
+# Creates a .db file with records for one full standard set of jaws.
+
 file "$(JAWS)/jawsApp/Db/jawsheader.template" {
     { P=\$(P), JAWS=\$(JAWS), mXN=\$(mXN), mXS=\$(mXS), mXE=\$(mXE), mXW=\$(mXW), ASG=\$(ASG=DEFAULT) }
 }

--- a/jawsApp/Db/jaws_vertical.substitutions
+++ b/jawsApp/Db/jaws_vertical.substitutions
@@ -1,3 +1,5 @@
+# Create a .db file with records for a set of jaws that consists of vertical blades only (North and South)
+
 file "$(JAWS)/jawsApp/Db/jaws_vertical_header.template" {
     { P=\$(P), JAWS=\$(JAWS), mXN=\$(mXN), mXS=\$(mXS), ASG=\$(ASG=DEFAULT) }
 }

--- a/jawsApp/Db/split_jaws_header_vertical.substitutions
+++ b/jawsApp/Db/split_jaws_header_vertical.substitutions
@@ -1,0 +1,8 @@
+file "$(JAWS)/jawsApp/Db/jawsheader.template" {
+    { P=\$(P), JAWS=\$(JAWS), mXN=\$(mXN), mXS=\$(mXS), mXE=\$(mXE), mXW=\$(mXW), ASG=\$(ASG=DEFAULT) }
+}
+
+file "$(JAWS)/jawsApp/Db/slits.template" {
+    { P=\$(P), SLIT=\$(JAWS), M1=\$(mXN), M2=\$(mXS), S1=JN, S2=JS, D1=North, D2=South, GAP=VGAP, DGAP=Vertical, CENTRE=VCENT, DCENTRE=Vertical, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
+}
+

--- a/jawsApp/Db/split_jaws_header_vertical.substitutions
+++ b/jawsApp/Db/split_jaws_header_vertical.substitutions
@@ -1,3 +1,7 @@
+# Creates a .db file for the header and individual vertical blades of a split full set of jaws
+# This is needed where vertical and horizontal blades are controlled by separate motor IOCs and thus need to have their .dbs loaded separately.
+# Expects split_jaws_horizontal.db to be loaded to work correctly
+
 file "$(JAWS)/jawsApp/Db/jawsheader.template" {
     { P=\$(P), JAWS=\$(JAWS), mXN=\$(mXN), mXS=\$(mXS), mXE=\$(mXE), mXW=\$(mXW), ASG=\$(ASG=DEFAULT) }
 }

--- a/jawsApp/Db/split_jaws_horizontal.substitutions
+++ b/jawsApp/Db/split_jaws_horizontal.substitutions
@@ -1,0 +1,4 @@
+file "$(JAWS)/jawsApp/Db/slits.template" {
+    { P=\$(P), SLIT=\$(JAWS), M1=\$(mXE), M2=\$(mXW), S1=JE, S2=JW, D1=East, D2=West, GAP=HGAP, DGAP=Horizontal, CENTRE=HCENT, DCENTRE=Horizontal, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
+}
+

--- a/jawsApp/Db/split_jaws_horizontal.substitutions
+++ b/jawsApp/Db/split_jaws_horizontal.substitutions
@@ -1,3 +1,7 @@
+# Creates a .db file for the individual horizontal blades of a split full set of jaws
+# This is needed where vertical and horizontal blades are controlled by separate motor IOCs and thus need to have their .dbs loaded separately.
+# Expects split_jaws_header_vertical.db to be loaded to work correctly
+
 file "$(JAWS)/jawsApp/Db/slits.template" {
     { P=\$(P), SLIT=\$(JAWS), M1=\$(mXE), M2=\$(mXW), S1=JE, S2=JW, D1=East, D2=West, GAP=HGAP, DGAP=Horizontal, CENTRE=HCENT, DCENTRE=Horizontal, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
 }

--- a/settings/jaws_full/jaws.cmd
+++ b/settings/jaws_full/jaws.cmd
@@ -1,0 +1,3 @@
+REM Load records for standard full Jawset
+
+$(IFIOC_GALIL_01=#) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0101,mXS=MTR0102,mXW=MTR0103,mXE=MTR0104")

--- a/settings/jaws_full_split/jaws.cmd
+++ b/settings/jaws_full_split/jaws.cmd
@@ -1,0 +1,4 @@
+REM Load records for full jawset that is split over two separate motor controllers
+
+$(IFIOC_GALIL_01=#) dbLoadRecords("$(JAWS)/db/split_jaws_header_vertical.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0101,mXS=MTR0102,mXW=MTR0202,mXE=MTR0201")
+$(IFIOC_GALIL_02=#) dbLoadRecords("$(JAWS)/db/split_jaws_horizontal.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXW=MTR0202,mXE=MTR0201")

--- a/settings/jaws_vertical_only/jaws.cmd
+++ b/settings/jaws_vertical_only/jaws.cmd
@@ -1,2 +1,3 @@
+REM Load records for Jawset that only has vertical blades only
 
 $(IFIOC_GALIL_01) dbLoadRecords("$(JAWS)/db/jaws_vertical.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0101,mXS=MTR0102")


### PR DESCRIPTION
In addition to the regular `jaws.db`, building the jaws support directory now creates two dbs which contain records for just the vertical / horizontal jaw blades separately. This way these dbs can be loaded individually by separate IOCs. This allows Galil configurations where control of a jawset is split across two controllers.

Issue: https://github.com/ISISComputingGroup/IBEX/issues/4533

#### How to test:
Edit your `jaws.cmd` in the config area to load `split_jaws_vertical_header` and `split_jaws_horizontal` separately, e.g. given two running Galil IOCs `GALIL_01` and `GALIL_02` pointing at Controller 01 and 02 respectively:

```
$(IFIOC_GALIL_01=#) dbLoadRecords("$(JAWS)/db/split_jaws_header_vertical.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0101,mXS=MTR0102,mXW=MTR0202,mXE=MTR0201")
$(IFIOC_GALIL_02=#) dbLoadRecords("$(JAWS)/db/split_jaws_horizontal.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXW=MTR0202,mXE=MTR0201")
```

Confirm that the jaws behave correctly.

IOC tests PR: https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/204