### PR TITLE
Ticket 4303: Added an alias for jaws done on the controller

### DIFF
--- a/jawsApp/Db/Makefile
+++ b/jawsApp/Db/Makefile
@@ -13,6 +13,7 @@ include $(TOP)/configure/CONFIG
 #DB += xxx.db
 DB += jaws.db
 DB += jaws_vertical.db
+DB += jaws_alias.db
 DB += split_jaws_header_vertical.db
 DB += split_jaws_horizontal.db
 

--- a/jawsApp/Db/alias.template
+++ b/jawsApp/Db/alias.template
@@ -1,0 +1,22 @@
+# Creates aliases for all the normal jaw records for when the centres/gaps are actually described by real motor records
+
+record (ai, "$(P)$(SLIT)$(JAW_AXIS)") 
+{
+	field(DESC, "Current $(JAW_AXIS) position")
+	field(PREC, "3")
+	field(EGU, "$(EGU)")
+	field(INP, "$(P)$(MOTOR).RBV CP")
+    info(archive, "0.1 VAL")
+    info(INTEREST, "HIGH")
+}
+
+record (bi, "$(P)$(SLIT)$(JAW_AXIS):DMOV") 
+{
+	field(DESC, "True if $(JAW_AXIS) done moving")
+	field(INP, "$(P)$(MOTOR).DMOV CP")
+    info(INTEREST, "HIGH")
+}
+
+alias("$(P)$(MOTOR)", "$(P)$(SLIT)$(JAW_AXIS):SP")
+alias("$(P)$(SLIT)$(JAW_AXIS):SP", "$(P)$(SLIT)$(JAW_AXIS):SP:RBV")
+alias("$(P)$(MOTOR)", "$(P)$(SLIT)$(JAW_AXIS):MTR")

--- a/jawsApp/Db/jaws_alias.substitutions
+++ b/jawsApp/Db/jaws_alias.substitutions
@@ -1,0 +1,17 @@
+# Creates a .db file with alias records for one full standard set of jaws where the centres/gaps are calculated outside of EPICS.
+
+file "$(JAWS)/jawsApp/Db/jawsheader.template" {
+    { P=\$(P), JAWS=\$(JAWS), mXN=\$(mXN), mXS=\$(mXS), mXE=\$(mXE), mXW=\$(mXW), ASG=\$(ASG=DEFAULT) }
+}
+
+file "$(JAWS)/jawsApp/Db/alias.template" {
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mXN), JAW_AXIS=JN, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mXS), JAW_AXIS=JS, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mXE), JAW_AXIS=JE, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mXW), JAW_AXIS=JW, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mVCENT), JAW_AXIS=VCENT, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mVGAP), JAW_AXIS=VGAP, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mHCENT), JAW_AXIS=HCENT, EGU=\$(EGU=) }
+    { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mHGAP), JAW_AXIS=HGAP, EGU=\$(EGU=) }
+}
+

--- a/settings/jaws_alias/jaws.cmd
+++ b/settings/jaws_alias/jaws.cmd
@@ -1,0 +1,3 @@
+# Load records for an aliased full jawset
+
+$(IFIOC_TWINCAT_01=#) dbLoadRecords("$(JAWS)/db/jaws_alias.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0101,mXS=MTR0102,mXW=MTR0103,mXE=MTR0104,mVGAP=MTR0105,mVCENT=MTR0106,mHGAP=MTR0107,mHCENT=MTR0108,EGU=mm")


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4303

The gaps/centres of jaws are done in the controller for the coarse jaws. This means that our jaws logic is no longer required but it would still be good to follow the same interface for the jaws such that the OPI works exactly the same.

To test:
* Start up a simulated motor with 8 axes (a galil will be fine)
* Copy the provided jaws.cmd into your config area
* Run the jaws OPI, confirm that you can move the centre and gaps and they directly move motion axis