### PR TITLE
Ticket4695 jaws adel

### DIFF
--- a/jawsApp/Db/jaws.substitutions
+++ b/jawsApp/Db/jaws.substitutions
@@ -9,3 +9,9 @@ file "$(JAWS)/jawsApp/Db/slits.template" {
     { P=\$(P), SLIT=\$(JAWS), M1=\$(mXE), M2=\$(mXW), S1=JE, S2=JW, D1=East, D2=West, GAP=HGAP, DGAP=Horizontal, CENTRE=HCENT, DCENTRE=Horizontal, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
 }
 
+file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
+    {P=\$(P), TO=\$(JAWS)JN, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JE, FROM=\$(mXE), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JS, FROM=\$(mXS), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JW, FROM=\$(mXW), FIELD=ADEL}
+}

--- a/jawsApp/Db/jaws.substitutions
+++ b/jawsApp/Db/jaws.substitutions
@@ -14,4 +14,11 @@ file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
     {P=\$(P), TO=\$(JAWS)JE, FROM=\$(mXE), FIELD=ADEL}
     {P=\$(P), TO=\$(JAWS)JS, FROM=\$(mXS), FIELD=ADEL}
     {P=\$(P), TO=\$(JAWS)JW, FROM=\$(mXW), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VGAP, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)HGAP, FROM=\$(mXE), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VCENT, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)HCENT, FROM=\$(mXE), FIELD=ADEL}
+
 }

--- a/jawsApp/Db/jaws_alias.substitutions
+++ b/jawsApp/Db/jaws_alias.substitutions
@@ -15,3 +15,15 @@ file "$(JAWS)/jawsApp/Db/alias.template" {
     { P=\$(P), SLIT=\$(JAWS), MOTOR=\$(mHGAP), JAW_AXIS=HGAP, EGU=\$(EGU=) }
 }
 
+file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
+    {P=\$(P), TO=\$(JAWS)JN, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JE, FROM=\$(mXE), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JS, FROM=\$(mXS), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JW, FROM=\$(mXW), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VGAP, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)HGAP, FROM=\$(mXE), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VCENT, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)HCENT, FROM=\$(mXE), FIELD=ADEL}
+}

--- a/jawsApp/Db/jaws_vertical.substitutions
+++ b/jawsApp/Db/jaws_vertical.substitutions
@@ -7,3 +7,12 @@ file "$(JAWS)/jawsApp/Db/jaws_vertical_header.template" {
 file "$(JAWS)/jawsApp/Db/slits.template" {
     { P=\$(P), SLIT=\$(JAWS), M1=\$(mXN), M2=\$(mXS), S1=JN, S2=JS, D1=North, D2=South, GAP=VGAP, DGAP=Vertical, CENTRE=VCENT, DCENTRE=Vertical, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
 }
+
+file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
+    {P=\$(P), TO=\$(JAWS)JN, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JS, FROM=\$(mXS), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VGAP, FROM=\$(mXN), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VCENT, FROM=\$(mXN), FIELD=ADEL}
+}

--- a/jawsApp/Db/split_jaws_header_vertical.substitutions
+++ b/jawsApp/Db/split_jaws_header_vertical.substitutions
@@ -10,3 +10,12 @@ file "$(JAWS)/jawsApp/Db/slits.template" {
     { P=\$(P), SLIT=\$(JAWS), M1=\$(mXN), M2=\$(mXS), S1=JN, S2=JS, D1=North, D2=South, GAP=VGAP, DGAP=Vertical, CENTRE=VCENT, DCENTRE=Vertical, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
 }
 
+file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
+    {P=\$(P), TO=\$(JAWS)JN, FROM=\$(mXN), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JS, FROM=\$(mXS), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VGAP, FROM=\$(mXN), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)VCENT, FROM=\$(mXN), FIELD=ADEL}
+
+}

--- a/jawsApp/Db/split_jaws_horizontal.substitutions
+++ b/jawsApp/Db/split_jaws_horizontal.substitutions
@@ -6,3 +6,12 @@ file "$(JAWS)/jawsApp/Db/slits.template" {
     { P=\$(P), SLIT=\$(JAWS), M1=\$(mXE), M2=\$(mXW), S1=JE, S2=JW, D1=East, D2=West, GAP=HGAP, DGAP=Horizontal, CENTRE=HCENT, DCENTRE=Horizontal, ASG=\$(ASG=DEFAULT), EGU=\$(EGU=), CENT_DISP=\$(CENT_DISP=0) }
 }
 
+file "$(UTILITIES)/utilitiesApp/db/field_setter.template" {
+    {P=\$(P), TO=\$(JAWS)JE, FROM=\$(mXE), FIELD=ADEL}
+    {P=\$(P), TO=\$(JAWS)JW, FROM=\$(mXW), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)HGAP, FROM=\$(mXE), FIELD=ADEL}
+
+    {P=\$(P), TO=\$(JAWS)HCENT, FROM=\$(mXE), FIELD=ADEL}
+
+}


### PR DESCRIPTION
### Description of work

Adds records to copy the archive deadband field (ADEL) from the underlying motors to the jaw blades, gaps and centres. The gaps and centres take their ADEL values from one of the two driving motors, depending on the orientation.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/4695

### Acceptance criteria
- [ ] New records build correctly
- [ ] Jaw blades have ADEL set correctly
- [ ] Gaps and centres have ADEL values set from an appropriate underlying motor