### PR TITLE
Alias _IOCNAME and _able from underlying motor record in jaws

### DIFF
--- a/jawsApp/Db/slits.template
+++ b/jawsApp/Db/slits.template
@@ -495,3 +495,9 @@ record(stringin, "$(P)$(SLIT)$(S2):MOTOR") {
 alias("$(P)$(M1)", "$(P)$(SLIT)$(S1):MTR")
 alias("$(P)$(M2)", "$(P)$(SLIT)$(S2):MTR")
 
+alias("$(P)$(M1)_IOCNAME", "$(P)$(SLIT)$(S1):MTR_IOCNAME")
+alias("$(P)$(M2)_IOCNAME", "$(P)$(SLIT)$(S2):MTR_IOCNAME")
+
+alias("$(P)$(M1)_able", "$(P)$(SLIT)$(S1):MTR_able")
+alias("$(P)$(M2)_able", "$(P)$(SLIT)$(S2):MTR_able")
+


### PR DESCRIPTION
Reported by RD on LARMOR.

### To test:

- Set up a few recsim galils on your machine
- Define a jawset in `jaws.cmd` e.g.
```
$(IFIOC_GALIL_02=#) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0203,mXS=MTR0204,mXW=MTR0201,mXE=MTR0202,IFINIT_FROM_AS=$(IFINIT_JAWS_FROM_AS=#),IFNOTINIT_FROM_AS=$(IFNOTINIT_JAWS_FROM_AS=)")
```
- Setup a device screen as follows:
![image](https://github.com/ISISComputingGroup/EPICS-jaws/assets/24375813/829bf7ad-311f-4b58-8ce3-df44ffa0534f)
- Click "view motors"
- [x] Before this change is applied, "home" button is disconnected
- [x] After this change, "home" button works
- [x] As above but with the "enable/disable" button in the advanced motor screen
